### PR TITLE
ADD: bigquery data editor role

### DIFF
--- a/terraform/billing-reporter.tf
+++ b/terraform/billing-reporter.tf
@@ -85,6 +85,7 @@ resource "google_project_iam_member" "billing_report" {
   project = var.gcp_project_id
   for_each = toset([
     "roles/bigquery.dataViewer",
+    "roles/bigquery.dataEditor",
     "roles/bigquery.jobUser",
     "roles/bigquery.readSessionUser",
     "roles/cloudbuild.builds.builder",


### PR DESCRIPTION
- raised permission error. so, add roles/bigquery.dataEditor to billing-reporter service account
  - https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_function%22%0Aresource.labels.function_name%20%3D%20%22billing-reporter%22%0Aresource.labels.region%20%3D%20%22us-central1%22%0A%20severity%3E%3DDEFAULT;timeRange=2023-05-01T04:54:49.285912Z%2F2023-05-01T04:54:49.285912Z--PT1H;pinnedLogId=2023-05-01T04:54:49.285912Z%2F644f461900045cd8701db526?organizationId=1073439570018&project=haru256-billing-report&supportedpurview=project