### PR TITLE
FIX: downgrade cloud function action

### DIFF
--- a/.github/workflows/billing-reporter-deply.yml
+++ b/.github/workflows/billing-reporter-deply.yml
@@ -34,7 +34,7 @@ jobs:
           workload_identity_provider: ${{ vars.GH_GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GH_GCP_SERVICE_ACCOUNT }}
       - id: "deploy"
-        uses: "google-github-actions/deploy-cloud-functions@v3"
+        uses: "google-github-actions/deploy-cloud-functions@v2"
         with:
           name: "billing-reporter"
           project_id: ${{ vars.GCP_PROJECT_ID }}


### PR DESCRIPTION
### **User description**
## Description

- downgrade cloud function action
- `google-github-actions/deploy-cloud-functions@v3` is for cloud function gen2. But existing function is gen1, so is not supported.
- Becourse gen1 is supported according to google, so I use `google-github-actions/deploy-cloud-functions@v2` instead. 

https://cloud.google.com/functions/docs/concepts/version-comparison?hl=ja

> We recommend that you choose Cloud Functions (2nd gen) for new functions wherever possible. However, we plan to continue supporting Cloud Functions (1st gen).

## Reviewing Point


___

### **PR Type**
enhancement


___

### **Description**
- Downgraded the cloud function deployment action to support gen1 functions.
- Updated the action from `v3` to `v2` as `v3` is not compatible with gen1.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>billing-reporter-deply.yml</strong><dd><code>Downgrade Cloud Function Deployment Action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/billing-reporter-deply.yml

<li>Downgraded the action for deploying cloud functions.<br> <li> Changed from <code>google-github-actions/deploy-cloud-functions@v3</code> to <br><code>google-github-actions/deploy-cloud-functions@v2</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/haru-256/gcp-billing-reporter/pull/82/files#diff-32cf71892deddacc2411f7f3c440c608256cf9d4d21c1b464826122dd27de753">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

